### PR TITLE
Fix `this` binding in registerDestructor

### DIFF
--- a/addon/modifiers/picker.js
+++ b/addon/modifiers/picker.js
@@ -23,7 +23,7 @@ export default class PickerModifier extends Modifier {
   constructor() {
     super(...arguments);
 
-    registerDestructor(this, this.cleanup);
+    registerDestructor(this, () => this.picker.destroy());
   }
 
   /**
@@ -56,9 +56,5 @@ export default class PickerModifier extends Modifier {
     if (options.registerAPI && typeof options.registerAPI === 'function') {
       options.registerAPI(this.picker);
     }
-  }
-
-  cleanup() {
-    this.picker.destroy();
   }
 }


### PR DESCRIPTION
I love your add-on but it broke my tests, so I've asked in the [EmberJS discord](https://discord.com/channels/480462759797063690/483601670685720591/1026422316952981564) and got some help to pinpoint the issue. It's the same reason your tests fail.

https://api.emberjs.com/ember/4.7/functions/@ember%2Fdestroyable/registerDestructor